### PR TITLE
Fix output of running with unmodified config

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ We’ll be doing a little more configuration shortly when we start adding tests,
 It should output:
 
 ```
-0/0 tests passed
+0/0 tests failed
 ```
 
 Now that we’ve configured Intern, we need to create a test module which will contain the actual tests for our application.


### PR DESCRIPTION
With the unmodified example config and without any tests, intern actually reports `0/0 tests failed`. This surprised me and I thought I'd made an error, but continuing the tutorial it worked just fine.

This is on OS X, Node 0.11.13.
